### PR TITLE
Allow non-base64 encoded history files to render details

### DIFF
--- a/src/app/components/main/main.component.ts
+++ b/src/app/components/main/main.component.ts
@@ -66,8 +66,8 @@ export class MainComponent implements OnInit {
           time: element.time,
           mimetype: element.mimetype,
           extension: element.extension != 'null' ? element.extension : '',
-          request: this.parseReqRes(element.request),
-          response: this.parseReqRes(element.response)
+          request: this.atobReqRes(element.request),
+          response: this.atobReqRes(element.response)
         }
       )
       position += 1;
@@ -78,16 +78,12 @@ export class MainComponent implements OnInit {
     moveItemInArray(this.displayedColumns, event.previousIndex, event.currentIndex);
   }
 
-  private parseReqRes(query: any): string {
-    if (query[0].$.base64 === 'true') {
-      return this.atobReqRes(query);
-    }
-    return query[0]._;
-  }
-
   private atobReqRes(query: any): string {
     try {
-      return atob(query[0]._)
+      if (query[0].$.base64 === 'true') {
+        return this.atobReqRes(query);
+      }
+      return query[0]._;
     } catch (error) {
       console.log(error);
       console.log(query);

--- a/src/app/components/main/main.component.ts
+++ b/src/app/components/main/main.component.ts
@@ -66,8 +66,8 @@ export class MainComponent implements OnInit {
           time: element.time,
           mimetype: element.mimetype,
           extension: element.extension != 'null' ? element.extension : '',
-          request: this.atobReqRes(element.request),
-          response: this.atobReqRes(element.response)
+          request: this.parseReqRes(element.request),
+          response: this.parseReqRes(element.response)
         }
       )
       position += 1;
@@ -76,6 +76,13 @@ export class MainComponent implements OnInit {
 
   drop(event: CdkDragDrop<string[]>) {
     moveItemInArray(this.displayedColumns, event.previousIndex, event.currentIndex);
+  }
+
+  private parseReqRes(query: any): string {
+    if (query[0].$.base64 === 'true') {
+      return this.atobReqRes(query);
+    }
+    return query[0]._;
   }
 
   private atobReqRes(query: any): string {

--- a/src/app/components/main/main.component.ts
+++ b/src/app/components/main/main.component.ts
@@ -81,7 +81,7 @@ export class MainComponent implements OnInit {
   private atobReqRes(query: any): string {
     try {
       if (query[0].$.base64 === 'true') {
-        return this.atobReqRes(query);
+        return atob(query[0]._);
       }
       return query[0]._;
     } catch (error) {


### PR DESCRIPTION
Thank you for creating this tool, it's extremely useful.

As I was using it today I noticed that I wasn't able to see the details of an export I did that wasn't Base64 encoded, so I thought I'd see how difficult it would be to allow it to render non-Base64 encoded requests/responses.

Thanks in advance for taking the time to consider this PR.

Commit message:
------------------
Why:

* Burp suite has an option to allow the requests and responses from an
  HTTP history export to be either base64 or plain text.  The code for
  bhhb was only rendering the details for base64 encoded
  requests/responses.

This change addresses the need by:

* Updating the main.component to check if the request/response from the
  history file was base64 encoded and if so running it through the
  `atob` function and if not passing the plain text back.